### PR TITLE
Make setup.sql idempotent

### DIFF
--- a/setup/setup.sql
+++ b/setup/setup.sql
@@ -1,26 +1,26 @@
 -- Create the courseconnect database, and add the four tables
 
-CREATE DATABASE courseconnect;
+CREATE DATABASE IF NOT EXISTS courseconnect;
 USE courseconnect;
 
-CREATE TABLE courses (
+CREATE TABLE IF NOT EXISTS courses (
     id varchar(255),
     name varchar(255)
 );
 
-CREATE TABLE mentors (
+CREATE TABLE IF NOT EXISTS mentors (
     id varchar(255),
     first varchar(255),
     last varchar(255),
     email varchar(255)
 );
 
-CREATE TABLE connect (
+CREATE TABLE IF NOT EXISTS connect (
     studentID varchar(255),
     course varchar(255)
 );
 
-CREATE TABLE codes (
+CREATE TABLE IF NOT EXISTS codes (
     code varchar(255)
 );
 


### PR DESCRIPTION
Running `setup.sql` throws an error if the database and tables are already created; change this so that the database and tables are left alone if they are already created, avoiding errors.

This allows running the script a second time if one or more of the `tsv` files was not accessible the first time for whatever reason.