### PR TITLE
Clear tables in setup SQL scripts

### DIFF
--- a/setup/fill.sql
+++ b/setup/fill.sql
@@ -1,9 +1,13 @@
 -- Fill the courseconnect database with the test data
 
+USE courseconnect;
+
 SET GLOBAL local_infile = 'ON';
 
+DELETE FROM mentors;
 LOAD DATA LOCAL INFILE "setup/test-data/mentors.tsv" INTO TABLE mentors 
 FIELDS TERMINATED BY "\t" LINES TERMINATED BY "\r\n";
 
+DELETE FROM connect;
 LOAD DATA LOCAL INFILE "setup/test-data/connect.tsv" INTO TABLE connect 
 FIELDS TERMINATED BY "\t" LINES TERMINATED BY "\r\n";

--- a/setup/setup.sql
+++ b/setup/setup.sql
@@ -26,8 +26,10 @@ CREATE TABLE IF NOT EXISTS codes (
 
 SET GLOBAL local_infile = 'ON';
 
+DELETE FROM courses;
 LOAD DATA LOCAL INFILE "setup/test-data/courses.tsv" INTO TABLE courses 
 FIELDS TERMINATED BY "\t" LINES TERMINATED BY "\r\n";
 
+DELETE FROM codes;
 LOAD DATA LOCAL INFILE "setup/test-data/codes.tsv" INTO TABLE codes
 FIELDS TERMINATED BY "\t" LINES TERMINATED BY "\n";


### PR DESCRIPTION
Make sure that tables are cleared before importing new data in the setup scripts, to avoid duplication of data.