### PR TITLE
Automatically migrate database to new version

### DIFF
--- a/database.js
+++ b/database.js
@@ -37,6 +37,8 @@ function ensureVersion() {
 					if (err) throw err;
 					callback(...args);
 				});
+			} else {
+				callback(...args);
 			}
 		});
 	}
@@ -58,6 +60,8 @@ function ensureVersion() {
 					if (err) throw err;
 					callback(...args);
 				});
+			} else {
+				callback(...args);
 			}
 		});
 	}

--- a/database.js
+++ b/database.js
@@ -17,51 +17,67 @@ function init() {
 
 // Make sure that the database schema is up to date
 function ensureVersion() {
-    // Create the version table if not already created
-    const createTable = "CREATE TABLE IF NOT EXISTS version (ver varchar(8), timestamp varchar(255))";
-    connection.query(createTable, (err) => {
-        if (err) throw err;
-    });
-    // Insert the initial version if nonexistent
-    const firstVersion = "SELECT * FROM version";
-    connection.query(firstVersion, (err, rows) => {
-        if (err) throw err;
-        if (rows.length === 0) {
-            const addVer = "INSERT INTO version VALUES ('1.0.2', CURRENT_TIMESTAMP)";
-            connection.query(addVer, (err) => {
-                if (err) throw err;
-            });
-        }
-    });
-    // Detect older version of the database without pmsg column
-    const query = "SHOW COLUMNS FROM mentors LIKE 'pmsg'";
-    connection.query(query, (err, rows) => {
-        if (err) throw err;
-        if (rows.length === 0) {
-            // pmsg column not present
-            console.log("Database version 1.0.2 detected. Migrating to version 1.0.3...");
-            const addPmsg = "ALTER TABLE mentors ADD pmsg varchar(1)";
-            connection.query(addPmsg, (err) => {
-                if (err) throw err;
-            });
-            const setPmsg = "UPDATE mentors SET pmsg = '0'";
-            connection.query(setPmsg, (err) => {
-                if (err) throw err;
-            });
-        }
-    });
-    // Update the database version
-    const currentVersion = "SELECT ver FROM version";
-    connection.query(currentVersion, (err, rows) => {
-        if (err) throw err;
-        if (rows[rows.length - 1].ver === "1.0.2") {
-            const updateVersion = "INSERT INTO version VALUES ('1.0.3', CURRENT_TIMESTAMP)";
-            connection.query(updateVersion, (err) => {
-                if (err) throw err;
-            });
-            console.log("Migration to database version 1.0.3 complete.");
-        }
-    });
+	const createTable = (callback, ...args) => {
+		// Create the version table if not already created
+		const createTableQuery = "CREATE TABLE IF NOT EXISTS version (ver varchar(8), timestamp varchar(255))";
+		connection.query(createTableQuery, (err) => {
+			if (err) throw err;
+			callback(...args);
+		});
+	}
+
+	const firstVersion = (callback, ...args) => {
+		// Insert the initial version if nonexistent
+		const firstVersionQuery = "SELECT * FROM version";
+		connection.query(firstVersionQuery, (err, rows) => {
+			if (err) throw err;
+			if (rows.length === 0) {
+				const addVer = "INSERT INTO version VALUES ('1.0.2', CURRENT_TIMESTAMP)";
+				connection.query(addVer, (err) => {
+					if (err) throw err;
+					callback(...args);
+				});
+			}
+		});
+	}
+
+	const detectOlderVersion = (callback, ...args) => {
+		// Detect older version of the database without pmsg column
+		const query = "SHOW COLUMNS FROM mentors LIKE 'pmsg'";
+		connection.query(query, (err, rows) => {
+			if (err) throw err;
+			if (rows.length === 0) {
+				// pmsg column not present
+				console.log("Database version 1.0.2 detected. Migrating to version 1.0.3...");
+				const addPmsg = "ALTER TABLE mentors ADD pmsg varchar(1)";
+				connection.query(addPmsg, (err) => {
+					if (err) throw err;
+				});
+				const setPmsg = "UPDATE mentors SET pmsg = '0'";
+				connection.query(setPmsg, (err) => {
+					if (err) throw err;
+					callback(...args);
+				});
+			}
+		});
+	}
+
+	const updateVersion = () => {
+		// Update the database version
+		const currentVersion = "SELECT ver FROM version";
+		connection.query(currentVersion, (err, rows) => {
+			if (err) throw err;
+			if (rows[rows.length - 1].ver === "1.0.2") {
+				const updateVersion = "INSERT INTO version VALUES ('1.0.3', CURRENT_TIMESTAMP)";
+				connection.query(updateVersion, (err) => {
+					if (err) throw err;
+				});
+				console.log("Migration to database version 1.0.3 complete.");
+			}
+		});
+	}
+
+	createTable(firstVersion, detectOlderVersion, updateVersion);
 }
 
 module.exports = {

--- a/database.js
+++ b/database.js
@@ -1,0 +1,42 @@
+const mysql = require("mysql");
+const dotenv = require("dotenv");
+dotenv.config();
+
+let connection;
+
+function init() {
+    connection = mysql.createConnection({
+        host: process.env.DB_HOST,
+        user: process.env.DB_USER,
+        password: process.env.DB_PASSWORD,
+        database: process.env.DB_NAME
+    });
+    connection.connect();
+    return connection;
+}
+
+// Make sure that the database schema is up to date
+function ensureVersion() {
+    const query = "SHOW COLUMNS FROM mentors LIKE 'pmsg'";
+    connection.query(query, (err, rows) => {
+        if (err) throw err;
+        if (rows.length === 0) {
+            // pmsg column not present
+            console.log("Database version 1.0.2 detected. Migrating to version 1.0.3...");
+            const addPmsg = "ALTER TABLE mentors ADD pmsg varchar(1)";
+            connection.query(addPmsg, (err) => {
+                if (err) throw err;
+            });
+            const setPmsg = "UPDATE mentors SET pmsg = '0'";
+            connection.query(setPmsg, (err) => {
+                if (err) throw err;
+            });
+            console.log("Migration to database version 1.0.3 complete.");
+        }
+    });
+}
+
+module.exports = {
+    init,
+    ensureVersion,
+};

--- a/database.js
+++ b/database.js
@@ -21,10 +21,17 @@ function ensureVersion() {
     const createTable = "CREATE TABLE IF NOT EXISTS version (ver varchar(8), timestamp varchar(255))";
     connection.query(createTable, (err) => {
         if (err) throw err;
-        const addVer = "INSERT INTO version VALUES ('1.0.2', CURRENT_TIMESTAMP)";
-        connection.query(addVer, (err) => {
-            if (err) throw err;
-        });
+    });
+    // Insert the initial version if nonexistent
+    const firstVersion = "SELECT * FROM version";
+    connection.query(firstVersion, (err, rows) => {
+        if (err) throw err;
+        if (rows.length === 0) {
+            const addVer = "INSERT INTO version VALUES ('1.0.2', CURRENT_TIMESTAMP)";
+            connection.query(addVer, (err) => {
+                if (err) throw err;
+            });
+        }
     });
     // Detect older version of the database without pmsg column
     const query = "SHOW COLUMNS FROM mentors LIKE 'pmsg'";
@@ -47,7 +54,7 @@ function ensureVersion() {
     const currentVersion = "SELECT ver FROM version";
     connection.query(currentVersion, (err, rows) => {
         if (err) throw err;
-        if (rows[rows.length - 1] = "1.0.2") {
+        if (rows[rows.length - 1].ver === "1.0.2") {
             const updateVersion = "INSERT INTO version VALUES ('1.0.3', CURRENT_TIMESTAMP)";
             connection.query(updateVersion, (err) => {
                 if (err) throw err;

--- a/database.js
+++ b/database.js
@@ -1,5 +1,6 @@
 const mysql = require("mysql");
 const dotenv = require("dotenv");
+const package = require("./package.json");
 dotenv.config();
 
 let connection;
@@ -17,10 +18,22 @@ function init() {
 
 // Make sure that the database schema is up to date
 function ensureVersion() {
-    const query = "SHOW COLUMNS FROM mentors LIKE 'pmsg'";
-    connection.query(query, (err, rows) => {
+    // Add the current version to the "version" table if it is empty
+    const checkVer = "SHOW COLUMNS FROM version LIKE 'ver'";
+    connection.query(checkVer, (err, rows) => {
         if (err) throw err;
         if (rows.length === 0) {
+            const addVer = "INSERT INTO version VALUES (?)";
+            connection.query(addVer, [package.version], (err) => {
+                if (err) throw err;
+            });
+        }
+    });
+    // Detect older versions of the database
+    const query = "SELECT ver FROM version";
+    connection.query(query, (err, rows) => {
+        if (err) throw err;
+        if (rows[0] === "1.0.2") {
             // pmsg column not present
             console.log("Database version 1.0.2 detected. Migrating to version 1.0.3...");
             const addPmsg = "ALTER TABLE mentors ADD pmsg varchar(1)";
@@ -29,6 +42,11 @@ function ensureVersion() {
             });
             const setPmsg = "UPDATE mentors SET pmsg = '0'";
             connection.query(setPmsg, (err) => {
+                if (err) throw err;
+            });
+            // Update the database version
+            const updateVersion = "UPDATE version SET ver = '1.0.3'";
+            connection.query(updateVersion, (err) => {
                 if (err) throw err;
             });
             console.log("Migration to database version 1.0.3 complete.");

--- a/serve.js
+++ b/serve.js
@@ -4,19 +4,17 @@ const dotenv = require("dotenv");
 dotenv.config();
 const mysql = require("mysql");
 const port = process.env.PORT || 3000;
+const database = require("./database.js");
 
 app.use(express.json());
 app.use("/node_modules", express.static(__dirname + "/node_modules"));
 app.use(express.static(__dirname + "/public"));
 
 // Connect to the MySQL database
-const connection = mysql.createConnection({
-    host: process.env.DB_HOST,
-    user: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME
-});
-connection.connect();
+const connection = database.init();
+
+// Ensure that the database is up to date
+database.ensureVersion();
 
 // Direct to login first (will automatically redirect to home if user is logged in)
 app.get("/", (req, res) => {

--- a/setup/setup.sql
+++ b/setup/setup.sql
@@ -26,7 +26,8 @@ CREATE TABLE IF NOT EXISTS codes (
 );
 
 CREATE TABLE IF NOT EXISTS version (
-    ver varchar(8)
+    ver varchar(8),
+    timestamp varchar(255)
 );
 
 SET GLOBAL local_infile = 'ON';

--- a/setup/setup.sql
+++ b/setup/setup.sql
@@ -25,6 +25,10 @@ CREATE TABLE IF NOT EXISTS codes (
     code varchar(255)
 );
 
+CREATE TABLE IF NOT EXISTS version (
+    ver varchar(8)
+);
+
 SET GLOBAL local_infile = 'ON';
 
 DELETE FROM courses;


### PR DESCRIPTION
Fixes #45. If the database is in a format from an older version of Course Connect, detect this and migrate the database.

This is still a draft because I would also like to add a new table to the schema for keeping track of the database version; the migration code can add an entry to this table every time an upgrade is performed.